### PR TITLE
Fix dependencies and imports in SQL Storage section (s06)

### DIFF
--- a/docs/docs/06_sql_storage_sqlalchemy/02_create_simple_sqlalchemy_model/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/02_create_simple_sqlalchemy_model/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/02_create_simple_sqlalchemy_model/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/02_create_simple_sqlalchemy_model/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/03_one_to_many_relationships_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/04_configure_flask_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/05_insert_models_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/06_get_models_or_404/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/07_updating_models_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/end/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/end/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/end/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/08_retrieve_list_all_models/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/09_delete_models_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/09_delete_models_sqlalchemy/end/requirements.txt
@@ -1,5 +1,5 @@
 flask
-flask-smorest
 flask-sqlalchemy
+flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/09_delete_models_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/09_delete_models_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/end/models/store.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/end/models/store.py
@@ -7,4 +7,6 @@ class StoreModel(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(80), unique=True, nullable=False)
 
-    items = db.relationship("ItemModel", back_populates="store", lazy="dynamic")
+    items = db.relationship(
+        "ItemModel", back_populates="store", lazy="dynamic", cascade="all, delete"
+    )

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/end/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/end/requirements.txt
@@ -1,5 +1,5 @@
 flask
-flask-smorest
 flask-sqlalchemy
+flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/models/__init__.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/models/__init__.py
@@ -1,5 +1,2 @@
-from models.user import UserModel
 from models.item import ItemModel
-from models.tag import TagModel
 from models.store import StoreModel
-from models.item_tags import ItemsTags

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/requirements.txt
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-sqlalchemy
 flask-smorest
 python-dotenv
 marshmallow

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/resources/item.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/resources/item.py
@@ -18,7 +18,9 @@ class Item(MethodView):
 
     def delete(self, item_id):
         item = ItemModel.query.get_or_404(item_id)
-        raise NotImplementedError("Deleting an item is not implemented.")
+        db.session.delete(item)
+        db.session.commit()
+        return {"message": "Item deleted."}
 
     @blp.arguments(ItemUpdateSchema)
     @blp.response(200, ItemSchema)

--- a/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/resources/store.py
+++ b/docs/docs/06_sql_storage_sqlalchemy/10_delete_related_models_sqlalchemy/start/resources/store.py
@@ -19,7 +19,9 @@ class Store(MethodView):
 
     def delete(self, store_id):
         store = StoreModel.query.get_or_404(store_id)
-        raise NotImplementedError("Deleting a store is not implemented.")
+        db.session.delete(store)
+        db.session.commit()
+        return {"message": "Store deleted"}, 200
 
 
 @blp.route("/store")


### PR DESCRIPTION
While recording the video on cascades, I noticed that `flask-sqlalchemy` was missing from the `requirements.txt` in every `start`/`end` folder of this section.

Also, in `models/__init__.py` there were some extra imports that shouldn't have been there.